### PR TITLE
Remove duplicated logic while searching emoji

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ node_modules
 # Optional REPL history
 .node_repl_history
 
+# NPM lock files
+package-lock.json
+yarn.lock
+
 # 0x
 .__browserify_string_empty.js
 profile-*

--- a/src/search.js
+++ b/src/search.js
@@ -8,6 +8,7 @@ module.exports = function search (searchTerm) {
     const results = []
     emojiNames.forEach((name) => {
       const emoji = emojilib.lib[name].char
+      if (!emoji) return
       results.push({
         title: emoji,
         subtitle: `Copy "${emoji}" (${name}) to clipboard`,
@@ -29,6 +30,7 @@ module.exports = function search (searchTerm) {
     const results = []
     nameResults.forEach((name) => {
       const emoji = emojilib.lib[name].char
+      if (!emoji) return
       results.push({
         title: name,
         subtitle: `Copy "${emoji}" (${name}) to clipboard`,
@@ -50,6 +52,7 @@ module.exports = function search (searchTerm) {
   const results = []
   aliasResults.forEach((obj) => {
     const emoji = obj.char
+    if (!emoji) return
     results.push({
       title: obj._name,
       subtitle: `Copy "${emoji}" (${obj._name}) to clipboard`,

--- a/src/search.js
+++ b/src/search.js
@@ -3,64 +3,49 @@
 const emojilib = require('emojilib')
 const emojiNames = emojilib.ordered
 
-module.exports = function search (searchTerm) {
-  if (!searchTerm) {
-    const results = []
-    emojiNames.forEach((name) => {
-      const emoji = emojilib.lib[name].char
-      if (!emoji) return
-      results.push({
-        title: emoji,
-        subtitle: `Copy "${emoji}" (${name}) to clipboard`,
-        arg: emoji,
-        icon: { path: `./icons/${name}.png` }
-      })
-    })
-    return {items: results}
-  }
-
-  let ret = {items: []}
-
-  // search for the term within the names
-  const _searchTerm = searchTerm
-    .replace(/:/g, '') // :unamused: => unamused
-    .replace(/\s/g, '') // 'thumbs up' => 'thumbsup'
-  const nameResults = emojiNames.filter((name) => name === _searchTerm || name.includes(_searchTerm))
-  if (nameResults.length > 0) {
-    const results = []
-    nameResults.forEach((name) => {
-      const emoji = emojilib.lib[name].char
-      if (!emoji) return
-      results.push({
-        title: name,
-        subtitle: `Copy "${emoji}" (${name}) to clipboard`,
-        arg: emoji,
-        icon: { path: `./icons/${name}.png` }
-      })
-    })
-    ret.items = ret.items.concat(results)
-  }
-
-  // search for the term within the aliases
-  const aliasResults = []
-  for (var i = 0; i < emojiNames.length; i += 1) {
-    const obj = emojilib.lib[emojiNames[i]]
-    obj._name = emojiNames[i]
-    const filtered = obj.keywords.filter((keyword) => keyword.includes(_searchTerm))
-    if (filtered.length > 0) aliasResults.push(obj)
-  }
+const formattedResults = (names) => {
   const results = []
-  aliasResults.forEach((obj) => {
-    const emoji = obj.char
+  names.forEach((name) => {
+    const emoji = emojilib.lib[name].char
     if (!emoji) return
     results.push({
-      title: obj._name,
-      subtitle: `Copy "${emoji}" (${obj._name}) to clipboard`,
+      title: name,
+      subtitle: `Copy "${emoji}" (${name}) to clipboard`,
       arg: emoji,
-      icon: { path: `./icons/${obj._name}.png` }
+      icon: { path: `./icons/${name}.png` }
     })
   })
-  ret.items = ret.items.concat(results)
+  return results
+}
+
+const all = () => formattedResults(emojiNames)
+
+// search within the names
+const matchingName = (searchTerm) => {
+  const names = emojiNames.filter((name) => name.includes(searchTerm))
+  return formattedResults(names)
+}
+
+// search within the aliases
+const matchingAlias = (searchTerm) => {
+  const names = []
+  emojiNames.forEach((name) => {
+    if (emojilib.lib[name].keywords.some((keyword) => keyword.includes(searchTerm))) {
+      names.push(name)
+    }
+  })
+  return formattedResults(names)
+}
+
+module.exports = function search (searchTerm) {
+  if (!searchTerm) return { items: all() }
+
+  const _searchTerm = searchTerm.replace(/[:\s]/g, '') // :thumbs up: => thumbsup
+
+  const ret = { items: [] }
+
+  ret.items = ret.items.concat(matchingName(_searchTerm))
+  ret.items = ret.items.concat(matchingAlias(_searchTerm))
 
   const uniq = new Set(ret.items)
   ret.items = Array.from(uniq)

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -15,7 +15,7 @@ test('finds "thu" partial', (t) => {
   t.ok(Object.keys(found.items).length > 4)
 })
 
-test('finds "vomit"', (t) => {
+test('finds "vomit" keyword', (t) => {
   t.plan(1)
   const found = search('vomit')
   t.ok(Object.keys(found.items).length > 0)

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -20,3 +20,9 @@ test('finds "vomit"', (t) => {
   const found = search('vomit')
   t.ok(Object.keys(found.items).length > 0)
 })
+
+test('omits "rage1"', (t) => {
+  t.plan(1)
+  const found = search('rage1')
+  t.ok(Object.keys(found.items).length === 0)
+})


### PR DESCRIPTION
## What does it do?

While tackling #3, I noticed that the same logic was duplicated 3 times while searching through emoji.  This PR is a refactor that removes the duplication while also extracting most of the logic out into well-named functions. 

This results in the main function trimming down to this:

```js
module.exports = function search (searchTerm) {
  if (!searchTerm) return { items: all() }

  const _searchTerm = searchTerm.replace(/[:\s]/g, '') // :thumbs up: => thumbsup

  const ret = { items: [] }

  ret.items = ret.items.concat(matchingName(_searchTerm))
  ret.items = ret.items.concat(matchingAlias(_searchTerm))

  const uniq = new Set(ret.items)
  ret.items = Array.from(uniq)
  return ret
}
```

## What else do you need to know?

- This PR is stacked on top of #3, so be sure to merge that one first, or ignore that one if this one is merged first.


  