### PR TITLE
Fix support for spaces in query

### DIFF
--- a/src/info.plist.xml
+++ b/src/info.plist.xml
@@ -54,9 +54,9 @@
         <key>runningsubtext</key>
         <string>Loading results...</string>
         <key>script</key>
-        <string>query=$1
+        <string>query=$*
 
-./node emoji.js $query</string>
+./node emoji.js "$query"</string>
         <key>scriptargtype</key>
         <integer>1</integer>
         <key>scriptfile</key>


### PR DESCRIPTION
## What does it do?

- Fixes support for spaces from the original Alfred query

Before, if you performed a `emoji thumbs up` search in Alfred, only `thumbs` would be passed to the underlying search function.  This change ensures that the entire query is now passed to the search function (i.e. `thumbs up`).

You can test the broken behavior in the existing version by noticing that `emoji thumbs up` returns both :+1: and :-1:.

After applying this fix, `emoji thumbs up` will correctly return just :+1:.

