### PR TITLE
Add alt modifier and autocomplete support

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -18,6 +18,18 @@ workflow instead of trusting the [provided binary][releases].
 [node]: https://nodejs.org/
 [releases]: https://github.com/jsumners/alfred-emoji/releases
 
+## Usage
+
+```
+emoji [query]
+```
+
+Press <kbd>enter</kbd>: the **symbol** of the selected emoji (e.g. 🤣)
+will be copied to your clipboard.
+
+Press <kbd>alt</kbd>+<kbd>enter</kbd>: the **code** of the selected
+emoji (e.g. `:rofl:`) will be copied to your clipboard.
+
 ## Building The Workflow
 
 1. Clone this repository

--- a/src/search.js
+++ b/src/search.js
@@ -12,6 +12,7 @@ const formattedResults = (names) => {
       title: name,
       subtitle: `Copy "${emoji}" (${name}) to clipboard`,
       arg: emoji,
+      autocomplete: name,
       icon: { path: `./icons/${name}.png` }
     })
   })

--- a/src/search.js
+++ b/src/search.js
@@ -13,7 +13,13 @@ const formattedResults = (names) => {
       subtitle: `Copy "${emoji}" (${name}) to clipboard`,
       arg: emoji,
       autocomplete: name,
-      icon: { path: `./icons/${name}.png` }
+      icon: { path: `./icons/${name}.png` },
+      mods: {
+        alt: {
+          subtitle: `Copy ":${name}:" (${emoji}) to clipboard`,
+          arg: `:${name}:`
+        }
+      }
     })
   })
   return results

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -26,3 +26,9 @@ test('omits "rage1"', (t) => {
   const found = search('rage1')
   t.ok(Object.keys(found.items).length === 0)
 })
+
+test('enables autocomplete', (t) => {
+  t.plan(1)
+  const found = search('think')
+  t.ok(found.items[0].autocomplete === 'thinking')
+})

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -32,3 +32,9 @@ test('enables autocomplete', (t) => {
   const found = search('think')
   t.ok(found.items[0].autocomplete === 'thinking')
 })
+
+test('enables alt-modifier', (t) => {
+  t.plan(1)
+  const found = search('hear_no_evil')
+  t.ok(found.items[0].mods.alt.arg === ':hear_no_evil:')
+})


### PR DESCRIPTION
## What does it do?

- Adds <kbd>alt</kbd>-key modifier support for copying github/slack code. This will copy the github, slack, etc code (e.g. `:laughing:`) instead of the actual emoji symbol (e.g. :laughing:) when the ⌥  key (aka <kbd>alt</kbd> / <kbd>option</kbd>) is held.
- Adds autocomplete support
- Adds tests for both features
- Adds Usage documentation to README

## What else do you need to know?

- See `autocomplete` and `mods` options in [Alfred's Script Filter JSON Format](https://www.alfredapp.com/help/workflows/inputs/script-filter/json/)


  
  