### PR TITLE
Add support for pasting into frontmost app with cmd-key

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -32,11 +32,14 @@ workflow instead of trusting the [provided binary][releases].
 emoji [query]
 ```
 
-Press <kbd>enter</kbd>: the **symbol** of the selected emoji (e.g. 🤣)
-will be copied to your clipboard.
+Press <kbd>enter</kbd>: **Copy the symbol** of the selected emoji (e.g. 🤣) to
+your clipboard.
 
-Press <kbd>alt</kbd>+<kbd>enter</kbd>: the **code** of the selected
-emoji (e.g. `:rofl:`) will be copied to your clipboard.
+Press <kbd>alt</kbd>+<kbd>enter</kbd>: **Copy the code** of the selected emoji
+(e.g. `:rofl:`) to your clipboard.
+
+Press <kbd>cmd</kbd>+<kbd>enter</kbd>: **Paste the symbol** of the selected
+emoji (e.g. 🤣) directly to your frontmost application.
 
 ## Building the Workflow
 

--- a/src/info.plist.xml
+++ b/src/info.plist.xml
@@ -12,6 +12,16 @@
     <array>
       <dict>
         <key>destinationuid</key>
+        <string>AEDE6F2A-3933-4CB6-9F5B-0D53DDFE79BA</string>
+        <key>modifiers</key>
+        <integer>1048576</integer>
+        <key>modifiersubtext</key>
+        <string>Paste {query} into frontmost application</string>
+        <key>vitoclose</key>
+        <false/>
+      </dict>
+      <dict>
+        <key>destinationuid</key>
         <string>5A54554C-598A-41C6-B0D9-62046CEFB1AD</string>
         <key>modifiers</key>
         <integer>0</integer>
@@ -35,8 +45,29 @@
     <dict>
       <key>config</key>
       <dict>
+        <key>autopaste</key>
+        <true/>
+        <key>clipboardtext</key>
+        <string>{query}</string>
+        <key>transient</key>
+        <true/>
+      </dict>
+      <key>type</key>
+      <string>alfred.workflow.output.clipboard</string>
+      <key>uid</key>
+      <string>AEDE6F2A-3933-4CB6-9F5B-0D53DDFE79BA</string>
+      <key>version</key>
+      <integer>2</integer>
+    </dict>
+    <dict>
+      <key>config</key>
+      <dict>
         <key>alfredfiltersresults</key>
         <false/>
+        <key>alfredfiltersresultsmatchmode</key>
+        <integer>0</integer>
+        <key>argumenttrimmode</key>
+        <integer>0</integer>
         <key>argumenttype</key>
         <integer>1</integer>
         <key>escaping</key>
@@ -112,6 +143,13 @@
       <integer>490</integer>
       <key>ypos</key>
       <integer>300</integer>
+    </dict>
+    <key>AEDE6F2A-3933-4CB6-9F5B-0D53DDFE79BA</key>
+    <dict>
+      <key>xpos</key>
+      <integer>490</integer>
+      <key>ypos</key>
+      <integer>100</integer>
     </dict>
   </dict>
   <key>version</key>


### PR DESCRIPTION
Now, if you press <kbd>cmd</kbd>+<kbd>enter</kbd>, it will automatically paste the emoji into the frontmost application.

<img width="590" alt="alfred preferences 2018-01-10 15-11-31" src="https://user-images.githubusercontent.com/740/34798251-8db731be-f618-11e7-9b1f-9c71ce6ee259.png">