### PR TITLE
Add auto-update support by fetching from github releases

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -41,6 +41,13 @@ Press <kbd>alt</kbd>+<kbd>enter</kbd>: **Copy the code** of the selected emoji
 Press <kbd>cmd</kbd>+<kbd>enter</kbd>: **Paste the symbol** of the selected
 emoji (e.g. 🤣) directly to your frontmost application.
 
+## Automatic Updates
+
+This workflow will automatically check for updates at most once per day. If a
+new release is found, it automatically downloads and installs the latest
+version of the workflow. All downloads come directly from official [GitHub
+releases][releases].
+
 ## Building the Workflow
 
 1. Clone this repository

--- a/build.sh
+++ b/build.sh
@@ -15,9 +15,6 @@ cp ${parentDir}/src/emoji.js .
 cp ${parentDir}/src/search.js .
 cp ${parentDir}/src/info.plist.xml ./info.plist
 
-readme="${parentDir}/src/Readme.md"
-sed -i '' -e "/{{readme}}/{r ${readme}" -e 'd' -e '}' info.plist
-
 echo "Installing emojilib ..."
 npm install --silent --prefix ./ emojilib
 ltsVersion=$(${parentDir}/lib/getLTSversion.sh)
@@ -43,13 +40,17 @@ cd ..
 cp icons/beer.png ./icon.png
 
 echo "Updating version ..."
-curVersion=$(cat ../package.json | jq '.version' | sed 's/"//g')
+curVersion=$(cat ${parentDir}/package.json | jq '.version' | sed 's/"//g')
 sed -i '' 's/{{version}}/'${curVersion}'/' info.plist
 
+echo "Injecting readme ..."
+readme="${parentDir}/src/Readme.md"
+sed -i '' -e "/{{readme}}/{r ${readme}" -e 'd' -e '}' info.plist
+
 echo "Injecting auto-update script ..."
-tmpfile="$(mktemp)"
-cat ../src/update.sh | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' > ${tmpfile}
-sed -i '' -e "/{{update_script}}/{r ${tmpfile}" -e 'd' -e '}' info.plist
+update="$(mktemp)"
+cat ${parentDir}/src/update.sh | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' > ${update}
+sed -i '' -e "/{{update_script}}/{r ${update}" -e 'd' -e '}' info.plist
 
 echo "Bundling workflow ..."
-zip -Z deflate -rq9 ../alfred-emoji.alfredworkflow * -x etc
+zip -Z deflate -rq9 ${parentDir}/alfred-emoji.alfredworkflow * -x etc

--- a/build.sh
+++ b/build.sh
@@ -43,5 +43,10 @@ echo "Updating version ..."
 curVersion=$(cat ../package.json | jq '.version' | sed 's/"//g')
 sed -i '' 's/{{version}}/'${curVersion}'/' info.plist
 
+echo "Injecting auto-update script ..."
+tmpfile="$(mktemp)"
+cat ../src/update.sh | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' > ${tmpfile}
+sed -i '' -e "/{{update_script}}/{r ${tmpfile}" -e 'd' -e '}' info.plist
+
 echo "Bundling workflow ..."
 zip -Z deflate -rq9 ../alfred-emoji.alfredworkflow * -x etc

--- a/src/Readme.md
+++ b/src/Readme.md
@@ -10,6 +10,10 @@ alt + return (⌥↵) : Copy the code of the selected emoji (e.g. ":rofl:") to y
 
 cmd + return (⌘↵) : Paste the symbol of the selected emoji (e.g. 🤣) directly to your frontmost application.
 
+## Automatic Updates
+
+This workflow will automatically check for updates at most once per day. If a new release is found, it automatically downloads and installs the latest version of the workflow. All downloads come directly from official GitHub releases.
+
 ## Support
 
 For assistance with issues, or to submit a feature request, please visit:

--- a/src/info.plist.xml
+++ b/src/info.plist.xml
@@ -207,7 +207,7 @@
     <key>F5CA3331-1B99-45EF-8E9A-06C417387250</key>
     <dict>
       <key>note</key>
-      <string>Auto Update</string>
+      <string>Auto Update - remove to disable</string>
       <key>xpos</key>
       <integer>760</integer>
       <key>ypos</key>

--- a/src/info.plist.xml
+++ b/src/info.plist.xml
@@ -31,6 +31,32 @@
         <false/>
       </dict>
     </array>
+    <key>5A54554C-598A-41C6-B0D9-62046CEFB1AD</key>
+    <array>
+      <dict>
+        <key>destinationuid</key>
+        <string>F5CA3331-1B99-45EF-8E9A-06C417387250</string>
+        <key>modifiers</key>
+        <integer>0</integer>
+        <key>modifiersubtext</key>
+        <string></string>
+        <key>vitoclose</key>
+        <false/>
+      </dict>
+    </array>
+    <key>AEDE6F2A-3933-4CB6-9F5B-0D53DDFE79BA</key>
+    <array>
+      <dict>
+        <key>destinationuid</key>
+        <string>F5CA3331-1B99-45EF-8E9A-06C417387250</string>
+        <key>modifiers</key>
+        <integer>0</integer>
+        <key>modifiersubtext</key>
+        <string></string>
+        <key>vitoclose</key>
+        <false/>
+      </dict>
+    </array>
   </dict>
   <key>createdby</key>
   <string>James Sumners</string>
@@ -111,6 +137,31 @@
     <dict>
       <key>config</key>
       <dict>
+        <key>concurrently</key>
+        <false/>
+        <key>escaping</key>
+        <integer>102</integer>
+        <key>script</key>
+        <string>
+          {{update_script}}
+        </string>
+        <key>scriptargtype</key>
+        <integer>1</integer>
+        <key>scriptfile</key>
+        <string></string>
+        <key>type</key>
+        <integer>0</integer>
+      </dict>
+      <key>type</key>
+      <string>alfred.workflow.action.script</string>
+      <key>uid</key>
+      <string>F5CA3331-1B99-45EF-8E9A-06C417387250</string>
+      <key>version</key>
+      <integer>2</integer>
+    </dict>
+    <dict>
+      <key>config</key>
+      <dict>
         <key>autopaste</key>
         <false/>
         <key>clipboardtext</key>
@@ -146,10 +197,21 @@
     </dict>
     <key>AEDE6F2A-3933-4CB6-9F5B-0D53DDFE79BA</key>
     <dict>
+      <key>note</key>
+      <string>Auto Paste</string>
       <key>xpos</key>
       <integer>490</integer>
       <key>ypos</key>
       <integer>100</integer>
+    </dict>
+    <key>F5CA3331-1B99-45EF-8E9A-06C417387250</key>
+    <dict>
+      <key>note</key>
+      <string>Auto Update</string>
+      <key>xpos</key>
+      <integer>760</integer>
+      <key>ypos</key>
+      <integer>200</integer>
     </dict>
   </dict>
   <key>version</key>

--- a/src/update.sh
+++ b/src/update.sh
@@ -26,9 +26,10 @@ function fetch_download_url {
 }
 
 function download_and_install {
+  readonly tmpfile="$(mktemp).alfredworkflow"
   notification 'Downloading and installing…'
-  curl --silent --location --output "${HOME}/Downloads/${alfred_workflow_name}.alfredworkflow" "${1}"
-  open "${HOME}/Downloads/${alfred_workflow_name}.alfredworkflow"
+  curl --silent --location --output "${tmpfile}" "${1}"
+  open "${tmpfile}"
 }
 
 # Local sanity checks

--- a/src/update.sh
+++ b/src/update.sh
@@ -1,0 +1,48 @@
+# Based On The OneUpdater workflow, but heavily simplified for github releases
+# https://github.com/vitorgalvao/alfred-workflows/tree/master/OneUpdater
+
+# THESE VARIABLES MUST BE SET.
+readonly github_repo='jsumners/alfred-emoji'
+readonly frequency_check='1' # days
+
+# FROM HERE ON, CODE SHOULD BE LEFT UNTOUCHED!
+readonly info_plist='info.plist'
+
+function abort {
+  echo "${1}" >&2
+  exit 1
+}
+
+function notification {
+  osascript -e "display notification \"${1}\" with title \"${alfred_workflow_name}\" subtitle \"A new version is available\""
+}
+
+function fetch_remote_version {
+  curl --silent "https://api.github.com/repos/${github_repo}/releases/latest" | grep 'tag_name' | head -1 | sed -E 's/.*tag_name": "v?(.*)".*/\1/'
+}
+
+function fetch_download_url {
+  curl --silent "https://api.github.com/repos/${github_repo}/releases/latest" | grep 'browser_download_url.*\.alfredworkflow"' | head -1 | sed -E 's/.*browser_download_url": "(.*)".*/\1/'
+}
+
+function download_and_install {
+  notification 'Downloading and installing…'
+  curl --silent --location --output "${HOME}/Downloads/${alfred_workflow_name}.alfredworkflow" "${1}"
+  open "${HOME}/Downloads/${alfred_workflow_name}.alfredworkflow"
+}
+
+# Local sanity checks
+[[ -n "${alfred_workflow_version}" ]] || abort "'alfred_workflow_version' must be set."
+[[ -n "${alfred_workflow_name}" ]] || abort "'alfred_workflow_name' must be set."
+[[ "${github_repo}" =~ ^.+\/.+$ ]] || abort "'github_repo' (${github_repo}) must be in the format 'username/repo'."
+[[ "${frequency_check}" =~ ^[0-9]+$ ]] || abort "'frequency_check' (${frequency_check}) must be a number."
+
+# Check for updates
+if [[ $(find "${info_plist}" -mtime +"${frequency_check}"d) ]]; then
+  if [[ "${alfred_workflow_version}" == "$(fetch_remote_version)" ]]; then
+    touch "${info_plist}" # Reset timer by touching local file
+    exit 0
+  fi
+
+  download_and_install "$(fetch_download_url)"
+fi


### PR DESCRIPTION
## What does it do?

- Adds automatic updating support to the workflow
- After every emoji search, it determines whether it should check for updates (it will only do this once per day)
- If it recognizes that a new GitHub release was published (the latest released version is different from the currently installed version), it will **automatically download and install** the `*.alfredworkflow` attachment assigned to the latest GitHub release.

## What else do you need to know?

This update script was heavily based on the [OneUpdater workflow](https://github.com/vitorgalvao/alfred-workflows/tree/master/OneUpdater), but it was also modified to only work with GitHub releases.  

While reviewing, `update.sh` is the most relevent.

## Related Issues

- Closes #13

## Screenshots

<img width="901" alt="alfred preferences 2018-01-11 14-41-49" src="https://user-images.githubusercontent.com/740/34848857-a53c5c40-f6dd-11e7-85ca-66693bc4c5a0.png">

