### PR TITLE
Search for emoji with just one pass

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -32,16 +32,11 @@ const alfredItems = (names) => {
 
 const all = () => alfredItems(emojiNames)
 
-const matchingName = (terms) => {
-  return emojiNames.filter((name) => {
-    return terms.every((term) => name.includes(term))
-  })
-}
-
-const matchingAlias = (terms) => {
+const matches = (terms) => {
   return emojiNames.filter((name) => {
     return terms.every((term) => {
-      return emojilib.lib[name].keywords.some((keyword) => keyword.includes(term))
+      return name.includes(term) ||
+        emojilib.lib[name].keywords.some((keyword) => keyword.includes(term))
     })
   })
 }
@@ -54,8 +49,5 @@ module.exports = function search (query) {
 
   const terms = parse(query)
 
-  const names = matchingName(terms)
-        .concat(matchingAlias(terms))
-
-  return alfredItems(new Set(names))
+  return alfredItems(matches(terms))
 }

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -70,3 +70,9 @@ test('finds "plant nature"', (t) => {
   const found = search('plant nature')
   t.ok(Object.keys(found.items).length > 0)
 })
+
+test('finds "fruit banana"', (t) => {
+  t.plan(1)
+  const found = search('fruit banana')
+  t.ok(Object.keys(found.items).length > 0)
+})


### PR DESCRIPTION
## What does it do?

- Performance refactor
- Single pass over all emojis for each search instead of two passes
- No longer a need to run yet a third pass (while building the `Set` to make the results unique).
- This also has the nice side effect of being able to continue to narrow a search by continuing to add new words to the original query. For example, a search for `fruit banana` did not yield any results before, but now it does (as expected). (Note the new test that would have failed prior to this)

<img width="611" alt="screen shot 2018-01-12 at 12 43 41 pm" src="https://user-images.githubusercontent.com/740/34892375-4a956f2a-f796-11e7-881f-02d7b5735bf0.png">

<img width="611" alt="screen shot 2018-01-12 at 12 42 35 pm" src="https://user-images.githubusercontent.com/740/34892329-1e06a6e0-f796-11e7-8f9a-535372b4fd02.png">


