### PR TITLE
Build on `macos-latest`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,27 +8,14 @@ on:
 
 jobs:
   macosx:
-    runs-on: macos-10.15
+    runs-on: macos-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/setup-node@v2
     - run: npm install
     - run: npm test
     - run: ./build.sh
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       with:
-        name: alfred-emoji-macosx.alfredworkflow
+        name: alfred-emoji.alfredworkflow
         path: alfred-emoji.alfredworkflow
-
-  # macos11:
-  #   runs-on: macos-11.0
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #   - uses: actions/setup-node@v1
-  #   - run: npm install
-  #   - run: npm test
-  #   - run: ./build.sh
-  #   - uses: actions/upload-artifact@v1
-  #     with:
-  #       name: alfred-emoji-macos11.alfredworkflow
-  #       path: alfred-emoji.alfredworkflow

--- a/Readme.md
+++ b/Readme.md
@@ -7,6 +7,17 @@ them to the clipboard 🤘.
 
 ![screenshot](images/screenshot.png)
 
+> ## Note About Available Emoji
+>
+> The workflow is built against the latest available macOS within the GitHub
+> continuous integration infrastructure. This means some emoji may be missing
+> until the GitHub infrastructure is updated. It also means that some emoji
+> may be present in the workflow that do not exist on your system if your
+> system is running an earlier version of macOS.
+>
+> If this is not desired, follow the instructions below for generating the
+> workflow on your own system.
+
 ## Installing the Workflow
 
 [Download the provided Alfred workflow][releases].


### PR DESCRIPTION
https://github.com/actions/virtual-environments for the current available macOS environments. At this time, `macos-latest` maps to macOS 11 (despite macOS 12 being the true "latest").

Taking the stance in the PR reduces complexity in building releases. Originally, I wanted to build for all available macOS environments available in CI, but that introduced breakage in the auto-update script. Fixing that is something that I am not interested in. If someone else wants to take it on, we can certainly evaluate a PR to implement it.