### PR TITLE
Added support for copying codepoints (issue #57)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,6 +37,9 @@ your clipboard.
 Press <kbd>alt</kbd>+<kbd>return</kbd> (⌥↵): **Copy the code** of the selected emoji)
 (e.g. `:rofl:`) to your clipboard.
 
+Press <kbd>ctrl</kbd>+<kbd>return</kbd> (⌃↵): **Copy the codepoint** **of** the selected emoji)
+(e.g. `U+1F923`) to your clipboard.
+
 Press <kbd>shift</kbd>+<kbd>return</kbd> (⇧↵): **Copy the default symbol** of the selected emoji)
 (e.g. 🤣) to your clipboard without skin tone modifier.
 

--- a/lib/genpack.js
+++ b/lib/genpack.js
@@ -10,12 +10,6 @@ const emojiComponents = require('unicode-emoji-json/data-emoji-components')
 const keywordsMap = {}
 const emmojiInfo = {}
 
-const getCodePoint = (char) => {
-  const hex = char.codePointAt(0).toString(16).toUpperCase()
-  const leadingZeroes = hex.length < 4 ? '0'.repeat(4 - hex.length) : ''
-  return leadingZeroes + hex
-}
-
 const emojiSymbols = Object.keys(emojiKeywords)
 for (const emojiSymbol of emojiSymbols) {
   emojiKeywords[emojiSymbol].forEach(keyword => {
@@ -49,3 +43,8 @@ fs.writeFile(
     }
   }
 )
+
+function getCodePoint (char) {
+  const hex = char.codePointAt(0).toString(16).toUpperCase()
+  return hex.padStart(4, '0')
+}

--- a/lib/genpack.js
+++ b/lib/genpack.js
@@ -10,6 +10,12 @@ const emojiComponents = require('unicode-emoji-json/data-emoji-components')
 const keywordsMap = {}
 const emmojiInfo = {}
 
+const getCodePoint = (char) => {
+  const hex = char.codePointAt(0).toString(16).toUpperCase()
+  const leadingZeroes = hex.length < 4 ? '0'.repeat(4 - hex.length) : ''
+  return leadingZeroes + hex
+}
+
 const emojiSymbols = Object.keys(emojiKeywords)
 for (const emojiSymbol of emojiSymbols) {
   emojiKeywords[emojiSymbol].forEach(keyword => {
@@ -18,6 +24,7 @@ for (const emojiSymbol of emojiSymbols) {
     }
     keywordsMap[keyword].push(emojiSymbol)
   })
+  emojiData[emojiSymbol].codepoint = getCodePoint(emojiSymbol)
   emmojiInfo[emojiSymbol] = {
     ...emojiData[emojiSymbol],
     keywords: emojiKeywords[emojiSymbol]

--- a/src/Readme.md
+++ b/src/Readme.md
@@ -10,6 +10,8 @@ alt + return (⌥↵) : Copy the code of the selected emoji (e.g. ":rofl:") to y
 
 cmd + return (⌘↵) : Paste the symbol of the selected emoji (e.g. 🤣) directly to your frontmost application.
 
+ctrl + return (⌃↵): Copy the codepoint of the selected emoji (e.g. "U+1F923") to your clipboard.
+
 ## Automatic Updates
 
 This workflow will automatically check for updates at most once per day. If a new release is found, it automatically downloads and installs the latest version of the workflow. All downloads come directly from official GitHub releases.

--- a/src/search.js
+++ b/src/search.js
@@ -85,6 +85,12 @@ const alfredItem = (emojiDetails, emojiSymbol) => {
         subtitle: `${verb} "${emojiSymbol}" (${name}) ${preposition}`,
         arg: emojiSymbol,
         icon: { path: `./icons/${emojiDetails.slug}.png` }
+      },
+      // copy the codepoint for the emoji
+      ctrl: {
+        subtitle: `${verb} "U+${emojiDetails.codepoint}" (${emojiSymbol}) ${preposition}`,
+        arg: `U+${emojiDetails.codepoint}`,
+        icon: { path: `./icons/${emojiDetails.slug}.png` }
       }
     }
   }

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -182,3 +182,15 @@ test('finds 👨‍👩‍👦', (t) => {
   const found = search('family')
   t.equal(found.items.filter(i => i.title === 'family man, woman, boy').length, 1)
 })
+
+test('enables ctrl-modifier', (t) => {
+  t.plan(1)
+  const found = search('hear_no_evil')
+  t.ok(found.items[0].mods.ctrl.arg === 'U+1F649')
+})
+
+test('pads codepoint with zeroes if needed', (t) => {
+  t.plan(1)
+  const found = search('5')
+  t.ok(found.items[0].mods.ctrl.arg === 'U+0035')
+})


### PR DESCRIPTION
The only changes besides the readmes and such is adding the codepoint for each emoji to `'unicode-emoji-json'` in `genpack.js`. In order to avoid representing e.g. 5️⃣ as "U+35", I also wrote a function that adds leading zeroes to the codepoint so that the output looks as follows: "U+0035".

Here's a screenshot of the feature in action:
<img width="695" alt="image" src="https://user-images.githubusercontent.com/67383635/162406327-63b2e60a-c25d-428f-b0ff-2fb01c65721c.png">

Let me know what you think :)