### PR TITLE
Fixed line coverage

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -125,3 +125,7 @@ module.exports = function search (query, skinTone, pasteByDefault = false) {
 
   return alfredItems(matches(terms))
 }
+
+module.exports.internals = {
+  alfredItem
+}

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -182,3 +182,9 @@ test('finds 👨‍👩‍👦', (t) => {
   const found = search('family')
   t.equal(found.items.filter(i => i.title === 'family man, woman, boy').length, 1)
 })
+
+test('handles emoji the system does not recognize', (t) => {
+  t.plan(1)
+  const item = search.internals.alfredItem(undefined, '🤷🏼')
+  t.equal(item, undefined)
+})


### PR DESCRIPTION
Current line coverage is not 100%. In order to fix this, we have to test the line 64 in `search.js`
https://github.com/jsumners/alfred-emoji/blob/7658e90f79dc59dbdbf21dc6e9cf789b4991fba5/src/search.js#L59-L65

How it's done:
- in `search.js` added `alfredItem` to exports
- in `search.test.js` added a single test calling `alfredItem` with undefined and a random character as arguments