### PR TITLE
Do not auto-update to new major

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, v1 ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, v1 ]
 
 jobs:
   macosx:

--- a/Readme.md
+++ b/Readme.md
@@ -70,6 +70,16 @@ new release is found, it automatically downloads and installs the latest
 version of the workflow. All downloads come directly from official [GitHub
 releases][releases].
 
+By default, the update check will occur once per day. You can change the
+interval by setting the `update_check_frequency` environment variable in the
+[workflow environment variables](https://www.alfredapp.com/help/workflows/advanced/variables/#environment).
+The value may be any integer, and it defines the number of days between checks.
+
+If a new major version of the workflow is available, the workflow _will not_ be
+automatically updated. Major versions indicate potentially breaking changes
+or incompatibilities with older Alfred versions. Instead, a notification will
+be shown to remind you to manually update.
+
 ## Optional Hotkey and Snippet Triggers
 
 Trigger the workflow with either a custom hotkey or a custom snippet.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.12.0",
+  "version": "1.12.1",
   "scripts": {
     "webpack": "webpack",
     "clean": "rm -f *.alfredworkflow; rm -rf output/*",


### PR DESCRIPTION
This resolves #93. It prevents the workflow from automatically updating to the newest major version.