### PR TITLE
Upgrade 'unicode-emoji-json' to '0.4.0'

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.2.0",
-    "unicode-emoji-json": "^0.4.0",
+    "unicode-emoji-json": "^0.5.0",
     "webpack": "^5.72.1",
     "webpack-cli": "^4.9.2"
   }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
     "tap": "^16.2.0",
-    "unicode-emoji-json": "^0.3.1",
+    "unicode-emoji-json": "^0.4.0",
     "webpack": "^5.72.1",
     "webpack-cli": "^4.9.2"
   }

--- a/test/search.test.js
+++ b/test/search.test.js
@@ -198,5 +198,6 @@ test('enables ctrl-modifier', (t) => {
 test('pads codepoint with zeroes if needed', (t) => {
   t.plan(1)
   const found = search('5')
-  t.ok(found.items[0].mods.ctrl.arg === 'U+0035')
+  const unicodes = found.items.map((item) => item.mods.ctrl.arg)
+  t.ok(unicodes.includes('U+0035'))
 })


### PR DESCRIPTION
Changes:
- Upgrading `unicode-emoji-json` to version `0.4.0` due to `0.3.1` missing some of the more recent emoji.
- Fixing test that broke after upgrade. Unicode character `U+0035` is no longer in the first index of `found`. Update is more tolerant to index shuffling.