### PR TITLE
Update CI to use macOS 14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   macosx:
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@main
     - uses: actions/setup-node@main


### PR DESCRIPTION
See https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/