### PR TITLE
feat: Auto create release on merge to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-
+env:
+  ALFRED_WORKFLOW_FILE: 'alfred-emoji.alfredworkflow'
 jobs:
   macosx:
     runs-on: macos-latest
@@ -17,5 +18,56 @@ jobs:
     - run: ./build.sh
     - uses: actions/upload-artifact@main
       with:
-        name: alfred-emoji.alfredworkflow
-        path: alfred-emoji.alfredworkflow
+        name: ${{ env.ALFRED_WORKFLOW_FILE }}
+        path: ${{ env.ALFRED_WORKFLOW_FILE }}
+    - name: "Determine tag"
+      if: ${{ github.event_name == 'push' }}
+      run: |
+        RELEASE_VERSION=$(./build.sh get_current_version)
+        RELEASE_TAG="v${RELEASE_VERSION}"
+        echo "RELEASE_TAG=${RELEASE_TAG}" >> $GITHUB_ENV
+      shell: bash
+    - name: "Create release"
+      if: ${{ github.event_name == 'push' }}
+      uses: "actions/github-script@v7"
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        script: |
+          try {
+            const response = await github.rest.repos.createRelease({
+              draft: false,
+              generate_release_notes: true,
+              name: process.env.RELEASE_TAG,
+              owner: context.repo.owner,
+              prerelease: false,
+              repo: context.repo.repo,
+              tag_name: process.env.RELEASE_TAG,
+            });
+
+            core.exportVariable('RELEASE_ID', response.data.id);
+            core.exportVariable('RELEASE_UPLOAD_URL', response.data.upload_url);
+          } catch (error) {
+            core.setFailed(error.message);
+          }
+    - name: "Upload release asset"
+      if: ${{ github.event_name == 'push' }}
+      uses: "actions/github-script@v7"
+      env:
+        RELEASE_ASSET_FILE: ${{ env.ALFRED_WORKFLOW_FILE }}
+        RELEASE_ID: ${{ env.RELEASE_ID }}
+      with:
+        github-token: "${{ secrets.GITHUB_TOKEN }}"
+        script: |
+          try {
+            const fs = require('fs');
+            const response = await github.rest.repos.uploadReleaseAsset({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: process.env.RELEASE_ID,
+              name: process.env.RELEASE_ASSET_FILE,
+              data: await fs.readFileSync(process.env.RELEASE_ASSET_FILE)
+            });
+            core.exportVariable('DOWNLOAD_URL', response.data.browser_download_url);
+          } catch (error) {
+            core.setFailed(error.message);
+          }

--- a/build.sh
+++ b/build.sh
@@ -1,42 +1,83 @@
 #!/bin/bash
 set -e
+# deterime if the script is sourced or executed
+declare parentDir outputDir iconsDir
+init_dirs() {
+  # this script's parent directory
+  parentDir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd || return)
+  outputDir="${parentDir}/output"
+  iconsDir="${outputDir}/icons"
+  cd "${parentDir}" || return
+  mkdir -p "${outputDir}"
+  mkdir -p "${iconsDir}"
+  # make sure macos tools take precedence
+  PATH=/usr/bin:/bin:${PATH}
+}
+copy_info_plist() {
+  echo "Copying info.plist ..."
+  cp "${parentDir}/src/info.plist.xml" "${outputDir}/info.plist"
+}
+get_current_version() {
+  local version
+  version=$(node -e "console.log(require('${parentDir}/package.json').version)")
+  echo "${version}"
+}
 
-# this script's parent directory
-cd $(dirname $0)
-parentDir=$(pwd)
-
-[ ! -d output ] && mkdir output
-cd output
-
-cp ${parentDir}/src/info.plist.xml ./info.plist
-
-echo "Generating icons ..."
-[ ! -d icons ] && mkdir icons
-cd icons
-node ${parentDir}/lib/genicons.js
-cd ..
-cp icons/beer_mug.png ./icon.png
-
-echo "Creating emoji pack ..."
-cd ${parentDir}
-node ./lib/genpack.js
-
-echo "Generating jxa compatible source ..."
-npm run webpack
-
-echo "Updating version ..."
-cd output
-curVersion=$(node -e "console.log(require('${parentDir}/package.json').version)")
-sed -i '' 's/{{version}}/'${curVersion}'/' info.plist
-
-echo "Injecting readme ..."
-readme="${parentDir}/src/Readme.md"
-sed -i '' -e "/{{readme}}/{r ${readme}" -e 'd' -e '}' info.plist
-
-echo "Injecting auto-update script ..."
-update="$(mktemp)"
-cat ${parentDir}/src/update.sh | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' > ${update}
-sed -i '' -e "/{{update_script}}/{r ${update}" -e 'd' -e '}' info.plist
-
-echo "Bundling workflow ..."
-zip -Z deflate -rq9 ${parentDir}/alfred-emoji.alfredworkflow * -x etc
+generate_icons() {
+  cd "${iconsDir}" || return
+  echo "Generating icons ..."
+  node "${parentDir}/lib/genicons.js"
+  cd "${parentDir}" || return
+  cp "${iconsDir}/beer_mug.png" "${outputDir}/icon.png"
+}
+create_emojis_pack() {
+  echo "Creating emoji pack ..."
+  node "${parentDir}/lib/genpack.js"
+}
+generate_jxa_source() {
+  npm run webpack
+}
+update_version() {
+  local curVersion
+  curVersion=$(get_current_version)
+  echo "Updating version ..."
+  sed -i '' 's/{{version}}/'"${curVersion}"'/' "${outputDir}/info.plist"
+}
+inject_readme() {
+  local readme
+  readme="${parentDir}/src/Readme.md"
+  echo "Injecting readme ..."
+  sed -i '' -e "/{{readme}}/{r ${readme}" -e 'd' -e '}' "${outputDir}/info.plist"
+}
+inject_autoupdate_script() {
+  local update
+  update="$(mktemp)"
+  sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' "${parentDir}/src/update.sh" > "${update}"
+  echo "Injecting auto-update script ..."
+  sed -i '' -e "/{{update_script}}/{r ${update}" -e 'd' -e '}' "${outputDir}/info.plist"
+}
+bundle_workflow() {
+  echo "Bundling workflow ..."
+  cd "${outputDir}" || return
+  zip -Z deflate -rq9 "${parentDir}/alfred-emoji.alfredworkflow" -- * -x etc
+  cd "${parentDir}" || return
+}
+main() {
+  local run_func
+  run_func="${1}"
+  if [[ -z "${run_func}" ]]; then
+    init_dirs
+    copy_info_plist
+    generate_icons
+    create_emojis_pack
+    generate_jxa_source
+    update_version
+    inject_readme
+    inject_autoupdate_script
+    bundle_workflow
+  elif [[ -n "${run_func}" ]]; then
+    init_dirs
+    "${run_func}"
+  fi
+}
+main "$@"


### PR DESCRIPTION
* Updated build.sh script to support accepting an argument to run one of the build step functions. Using this to execute `get_current_version` to obtain the version number during workflow.
*  Added github-script steps in ci.yml to create a release and upload the workflow asset.

Fixes: issue #52