### PR TITLE
Bump emojilib for latest emoji

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   ],
   "devDependencies": {
     "c8": "^10.1.3",
-    "emojilib": "^4.0.1",
+    "emojilib": "^4.0.2",
     "fontkit": "^1.8.1",
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",


### PR DESCRIPTION
I noticed that 🫩 was missing, so I dug into it, seems like it's in the latest emojilib, so we just need to bump it to get it in here.