### PR TITLE
Fix workflow for macOS Tahoe 26.2+ where osascript run() output is suppressed

### DIFF
--- a/src/emoji-tahoe-fix.sh
+++ b/src/emoji-tahoe-fix.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Fix for macOS Tahoe 26.2 where osascript run() function output is completely suppressed
+# See: https://github.com/jsumners/alfred-emoji/issues/124
+#
+# This wrapper loads emoji.js and executes its logic WITHOUT relying on run()'s output
+
+QUERY="$1"
+
+/usr/bin/osascript -l JavaScript - "$QUERY" 2>&1 <<'JXASCRIPT' | grep -v '^[0-9][0-9][0-9][0-9]-' | grep '{"items"' | head -1
+ObjC.import('stdlib')
+ObjC.import('Foundation')
+
+// Get the query argument
+const args = $.NSProcessInfo.processInfo.arguments
+const query = ObjC.unwrap(args.objectAtIndex(args.count - 1))
+
+// Get environment variables (for skin_tone and snippetapp settings)
+function getenv(name) {
+  try {
+    const val = $.getenv(name)
+    return val ? ObjC.unwrap(val) : null
+  } catch (e) {
+    return null
+  }
+}
+
+// Read the emoji.js webpack bundle
+const scriptDir = getenv('PWD') || '.'
+const emojiJsPath = scriptDir + '/emoji.js'
+let emojiContent = ObjC.unwrap($.NSString.stringWithContentsOfFileEncodingError(
+  emojiJsPath,
+  $.NSUTF8StringEncoding,
+  null
+))
+
+// Execute the webpack bundle to load all modules
+eval(emojiContent)
+
+// Call run() and capture its return value
+const result = run([query])
+
+// Output using console.log (which WORKS outside of run())
+if (result) {
+  console.log(result)
+} else {
+  console.log('{"items":[{"title":"Error","subtitle":"No result from run()","arg":""}]}')
+}
+JXASCRIPT

--- a/src/emoji.js
+++ b/src/emoji.js
@@ -29,10 +29,13 @@ function getSkinTone () {
 
 // JXA: JavaScript for Automation Interface (`osascript -l JavaScript`)
 // Note: In JXA, console.log writes to stderr instead of stdout
+// IMPORTANT: In macOS Tahoe 26.2+, console.log in run() produces NO output
+// The return value is used by emoji-tahoe-fix.sh wrapper: https://github.com/jsumners/alfred-emoji/issues/124
 function run (argv) {
   const query = argv[0]
   const found = search(query, skinTone, pasteByDefault)
-  console.log(JSON.stringify(found))
+  console.log(JSON.stringify(found))  // Doesn't work in Tahoe 26.2+
+  return JSON.stringify(found)         // Return for wrapper script to capture
 }
 
 module.exports = run

--- a/src/info.plist.xml
+++ b/src/info.plist.xml
@@ -246,7 +246,7 @@
         <key>runningsubtext</key>
         <string>Loading results...</string>
         <key>script</key>
-        <string>osascript -l JavaScript emoji.js "$1" 2&gt;&amp;1</string>
+        <string>./emoji-tahoe-fix.sh "$1"</string>
         <key>scriptargtype</key>
         <integer>1</integer>
         <key>scriptfile</key>


### PR DESCRIPTION
# This is not intended to be a real PR, but rather "it works for me" and shows what I had to do (with @claude) to get this project running on macOS 26.2 Tahoe Developer Beta

## Root Cause Analysis

The issue affecting macOS Tahoe 26.2 (macOS 15+) is that **osascript completely suppresses all output from within the JXA `run()` function**. 

When you execute:
```bash
osascript -l JavaScript emoji.js "rocket" 2>&1
```

The `run()` function executes successfully (exit code 0), but `console.log()` inside it produces zero output on both stdout and stderr. This affects:
- `console.log()` 
- `$.system()` with output redirection
- Any other output mechanism called from within `run()`

Interestingly, `console.log()` works perfectly when called **outside** the `run()` function in the same JXA script.

## Proposed Fix

I've created a wrapper script `emoji-tahoe-fix.sh` that works around this macOS bug:

**How it works:**
1. Uses `osascript -l JavaScript -` (stdin mode) to execute JXA code **without** defining a `run()` function
2. Loads the emoji.js webpack bundle using `eval()`
3. Calls the `run()` function and captures its **return value** (not its output)
4. Uses `console.log()` in the outer context (not in `run()`) to output the JSON
5. Filters output to ensure clean single-line JSON for Alfred

**Key changes needed:**

1. **emoji.js** - Modify the `run()` function to return the JSON:
```javascript
function run (argv) {
  const query = argv[0]
  const found = search(query, skinTone, pasteByDefault)
  console.log(JSON.stringify(found))  // Doesn't work in Tahoe 26.2+
  return JSON.stringify(found)         // ADD THIS LINE
}
```

2. **emoji-tahoe-fix.sh** - New wrapper script (see below)

3. **info.plist** - Change the script command from:
```xml
<string>osascript -l JavaScript emoji.js "$1" 2&gt;&amp;1</string>
```
to:
```xml
<string>./emoji-tahoe-fix.sh "$1"</string>
```

**emoji-tahoe-fix.sh:**
```bash
#!/bin/bash
# Fix for macOS Tahoe 26.2 where osascript run() function output is completely suppressed
# See: https://github.com/jsumners/alfred-emoji/issues/124

QUERY="$1"

/usr/bin/osascript -l JavaScript - "$QUERY" 2>&1 <<'JXASCRIPT' | grep -v '^[0-9][0-9][0-9][0-9]-' | grep '{"items"' | head -1
ObjC.import('stdlib')
ObjC.import('Foundation')

// Get the query argument
const args = $.NSProcessInfo.processInfo.arguments
const query = ObjC.unwrap(args.objectAtIndex(args.count - 1))

// Get environment variables (for skin_tone and snippetapp settings)
function getenv(name) {
  try {
    const val = $.getenv(name)
    return val ? ObjC.unwrap(val) : null
  } catch (e) {
    return null
  }
}

// Read the emoji.js webpack bundle
const scriptDir = getenv('PWD') || '.'
const emojiJsPath = scriptDir + '/emoji.js'
let emojiContent = ObjC.unwrap($.NSString.stringWithContentsOfFileEncodingError(
  emojiJsPath,
  $.NSUTF8StringEncoding,
  null
))

// Execute the webpack bundle to load all modules
eval(emojiContent)

// Call run() and capture its return value
const result = run([query])

// Output using console.log (which WORKS outside of run())
if (result) {
  console.log(result)
} else {
  console.log('{"items":[{"title":"Error","subtitle":"No result from run()","arg":""}]}')
}
JXASCRIPT
```

## Testing

This fix has been tested on macOS 26.2 and successfully returns emoji search results:

```bash
$ ./emoji-tahoe-fix.sh rocket | jq -r '.items[3].title'
rocket

$ ./emoji-tahoe-fix.sh smiley | jq -r '.items | length'
8
```

The Alfred workflow now works correctly instead of falling back to DuckDuckGo search.

## Backwards Compatibility

The wrapper script should work on older macOS versions too since it doesn't rely on the broken `run()` output mechanism. However, testing on pre-Tahoe macOS would be valuable to confirm.
