### PR TITLE
build(deps): update unicode-emoji-json avoids genpack crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "pre-commit": "^1.2.2",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0",
-    "unicode-emoji-json": "^0.8.0",
+    "unicode-emoji-json": "^0.9.0",
     "webpack": "^5.72.1",
     "webpack-cli": "^4.9.2"
   }


### PR DESCRIPTION
Update to fix genpack crash - `TypeError: Cannot set properties of undefined (setting 'codepoint')`

Forgive me if I'm wrong, but I don't think this is a MacOS 26 error (I can't reproduce on my MacOS 26.5 / Tahoe machine). 

- [x] The code in this PR was 100% written by me, the person opening the PR.
