### PR TITLE
Improve search by letting Alfred filter results

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,23 +2,23 @@
 set -e
 
 # this script's parent directory
-cd $(dirname $0)
+cd "$(dirname $0)"
 parentDir=$(pwd)
 
 [ ! -d output ] && mkdir output
 cd output
 
-cp ${parentDir}/src/info.plist.xml ./info.plist
+cp "${parentDir}"/src/info.plist.xml ./info.plist
 
 echo "Generating icons ..."
 [ ! -d icons ] && mkdir icons
 cd icons
-node ${parentDir}/lib/genicons.js
+node "${parentDir}"/lib/genicons.js
 cd ..
 cp icons/beer_mug.png ./icon.png
 
 echo "Creating emoji pack ..."
-cd ${parentDir}
+cd "${parentDir}"
 node ./lib/genpack.js
 
 echo "Generating jxa compatible source ..."
@@ -35,8 +35,8 @@ sed -i '' -e "/{{readme}}/{r ${readme}" -e 'd' -e '}' info.plist
 
 echo "Injecting auto-update script ..."
 update="$(mktemp)"
-cat ${parentDir}/src/update.sh | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' > ${update}
+cat "${parentDir}"/src/update.sh | sed 's/&/\&amp;/g; s/</\&lt;/g; s/>/\&gt;/g' > ${update}
 sed -i '' -e "/{{update_script}}/{r ${update}" -e 'd' -e '}' info.plist
 
 echo "Bundling workflow ..."
-zip -Z deflate -rq9 ${parentDir}/alfred-emoji.alfredworkflow * -x etc
+zip -Z deflate -rq9 "${parentDir}"/alfred-emoji.alfredworkflow * -x etc

--- a/src/info.plist.xml
+++ b/src/info.plist.xml
@@ -224,9 +224,9 @@
       <key>config</key>
       <dict>
         <key>alfredfiltersresults</key>
-        <false/>
+        <true/>
         <key>alfredfiltersresultsmatchmode</key>
-        <integer>0</integer>
+        <integer>2</integer>
         <key>argumenttrimmode</key>
         <integer>0</integer>
         <key>argumenttype</key>

--- a/src/search.js
+++ b/src/search.js
@@ -71,6 +71,7 @@ const alfredItem = (emojiDetails, emojiSymbol) => {
     title: name,
     subtitle: `${verb} "${modifiedEmoji}" (${name}) ${preposition}`,
     arg: modifiedEmoji,
+    match: [name, ...emojiDetails.keywords].join(' '),
     autocomplete: name,
     icon: { path: `./icons/${icon}.png` },
     mods: {


### PR DESCRIPTION
<!--
Thank you for choosing to assist by contributing to this project. Please
read the following carefully before continuing.

DO NOT OPEN A PR WITH CODE PRODUCED BY AN LLM ("AI").
I **WILL NOT** accept PRs with such code, and will not even open the files
tab to look at the code. It is my opinion that such code is not able to
be licensed for open source contributions. Please read the following
link for more information: https://whoownsthecode.com/resources/.

You **must** acknowledge that you have read this and followed the
instructions by updating the checkbox below. In other words, place
an `x` between the brackets.

See https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/about-tasklists#creating-tasklists
-->

- [x] The code in this PR was 100% written by me, the person opening the PR.

I use this workflow every day, multiple times per day, so first of all, thanks!

My biggest frustration is that when I search for an emoji I use quite frequently, even when my query is the full name, "purple heart", 💜 isn't the first result. This PR turns on the `alfredfiltersresults` option (set to "Word matching - any order" mode) and adds a "match" property to support filtering based on alternate names. This results in a much better emoji search experience.

A great test of this is to search for "xd" and see that `:grinning_squiting_face:` (😆) is the top and only result. 